### PR TITLE
docs: add beginner-friendly CLI optional reading + README ToC/resources

### DIFF
--- a/OPTIONAL_READING_command-line.md
+++ b/OPTIONAL_READING_command-line.md
@@ -1,0 +1,45 @@
+# Optional Reading: Command Line Basics (Beginner-Friendly)
+
+These four text-first tutorials are the cleanest on-ramps to the Unix shell/Bash for absolute beginners. No logins, no friction—just clear steps you can practice and capture in your AI Learner’s Journal.
+
+---
+
+## 1) Software Carpentry — *The Unix Shell*
+**Link:** https://swcarpentry.github.io/shell-novice/  
+**Why this:** Classroom-tested lessons with tiny, progressive exercises—ideal as a first structured pass through navigation, files/dirs, pipes, and simple automation.
+
+---
+
+## 2) The Odin Project — *Command Line Basics*
+**Link:** https://www.theodinproject.com/lessons/foundations-command-line-basics  
+**Why this:** A single, focused primer that demystifies moving around and manipulating files without drowning you in jargon—perfect for a one-sitting on-ramp.
+
+---
+
+## 3) Ryan’s Tutorials — *Linux Tutorial for Beginners* (13-part)
+**Link:** https://ryanstutorials.net/linuxtutorial/  
+**Why this:** Bite-size pages in plain English with examples and shortcuts—great for incremental wins and a readable reference you can return to later.
+
+---
+
+## 4) Denys Dovhan — *Bash Handbook* (GitHub)
+**Link:** https://github.com/denysdovhan/bash-handbook  
+**Why this:** A concise, skimmable handbook that doubles as a lightweight reference once you start scripting; perfect for reinforcing habits and patterns.
+
+---
+
+## How to Use These with Your AI Learner’s Journal
+
+**Capture prompts (paste into your Journal):**
+- *After first session:* “List 5 commands I’ll reuse this week and 1 mistake I now know how to avoid.”  
+- *Pipes & redirects:* “Chain 2–3 commands I actually need (`|`, `>`, `>>`); explain each step in one sentence.”  
+- *Globbing & search:* “Write 2 ‘danger aware’ examples with `*` and `grep -R` and note safeguards.”  
+- *Mini-script:* “Create a 3–5 line Bash script that saves me 60 seconds/day; log before/after.”
+
+**Practice idea:** Convert one routine (renaming files, moving screenshots, or backing up a folder) into a single reusable command or tiny script. Add it to your Journal’s *Reusable Snippets* section.
+
+> Tip: Don’t memorize; **compose**. Use your Journal to record patterns you can remix later.
+
+---
+
+*Curated for AI Learner’s Journal Kit. Keep learning loops short, practical, and captured.*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # 📘 AI Learner's Journal Kit v3.0
 
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Learning Resources](#learning-resources)
+- [Contributing](#contributing)
+- [License](#license)
+
+
 [![GitHub Release](https://img.shields.io/github/v/release/Lawrence-Agbemabiese/AI-Learners-Journal-Kit-v3?label=Latest%20Release)](https://github.com/Lawrence-Agbemabiese/AI-Learners-Journal-Kit-v3/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Platform Support](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows-blue)](https://github.com/Lawrence-Agbemabiese/AI-Learners-Journal-Kit-v3)
@@ -314,3 +324,10 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 **Repository**: [AI-Learners-Journal-Kit-v3](https://github.com/Lawrence-Agbemabiese/AI-Learners-Journal-Kit-v3)
 
 🚀 **Happy Learning! Transform your AI conversations into lasting knowledge.**
+
+## Learning Resources
+
+- **Optional Reading → Command Line Basics:** See the curated, beginner-friendly set of four text tutorials to build core shell skills.  
+  → `./OPTIONAL_READING_command-line.md`
+
+> Use these alongside your Journal prompts: capture patterns you’ll reuse, not one-off commands.


### PR DESCRIPTION
## Summary
Adds a curated, beginner-friendly **Command Line Basics** reading page and surfaces it in the README with a slim **Table of Contents** and a **Learning Resources** section. This is documentation-only and non-breaking.

## Context
The AI Learner’s Journal Kit benefits from a gentle on-ramp to the Unix shell/Bash for absolute beginners. This PR introduces a tight, sign-in-free set of four text tutorials and ties them to reflective capture prompts—so new users don’t just read commands; they compose reusable patterns.

## Changes
- **New:** `OPTIONAL_READING_command-line.md` (four curated tutorials + “How to use with your Journal” capture prompts)
- **README:** 
  - Added a compact **Table of Contents** block
  - Added a **Learning Resources** section linking to the optional reading page

## How to Verify
1. Open `OPTIONAL_READING_command-line.md`:
   - Confirm all four links load and require no sign-in.
   - Skim the capture prompts and ensure formatting is clear on GitHub.
2. Open `README.md`:
   - Click **Table of Contents → Learning Resources** anchor (should jump correctly).
   - Click the **Optional Reading → Command Line Basics** link (should open the new page).
3. Optional link sweep: if you use `markdown-link-check` or similar, run it against `README.md` and the new page.

## Release Notes
- **Docs:** Added beginner-friendly command-line optional reading and surfaced it in the README.

## Checklist
- [ ] All links are accessible and free to read (no sign-in required)
- [ ] Markdown renders cleanly on GitHub (headings, lists, code fences)
- [ ] No changes to code or runtime paths
- [ ] Ready for merge once reviewed
