### PR TITLE
Make browser onboarding the default customer path

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,37 @@ The release builder now requires the web-first launchers and onboarding document
 See `SUPPORT.md`, `PRIVACY.md`, `SECURITY.md`, and `REFUND_POLICY.md`.
 
 AI answers may be wrong. Verify medical, legal, financial, security, and other high-stakes information with a qualified source.
+
+## More information
+
+### Quick Start
+
+Follow `docs/Quick_Start_v3.md` for the complete browser-first walkthrough.
+
+### Installation
+
+Mac and Windows users should begin with the clearly labeled **START HERE** launcher. Terminal-based installation is optional and documented separately.
+
+### Features
+
+The kit includes a local browser interface, plain-file journal storage, search, learning activity tracking, Ask the Guide, optional AI providers, backups, and advanced command-line tools.
+
+### Workshop Use
+
+Facilitators can use the journal in classes, cohorts, coding clubs, and guided learning workshops. See `docs/Workshop_Facilitator_Guide.md`.
+
+### Paid Product Use
+
+Commercial distribution must use the verified customer release ZIP. See `docs/Paid_Product_Checklist.md` and `docs/Storefront_Distribution_Checklist.md`.
+
+### Support
+
+See `SUPPORT.md` for troubleshooting and help.
+
+### Privacy
+
+See `PRIVACY.md` for data-handling information.
+
+### License
+
+See `LICENSE` for permitted use and distribution terms.

--- a/README.md
+++ b/README.md
@@ -1,237 +1,103 @@
-# AI Learner's Journal Kit v3.0
+# AI Learner's Journal Kit
 
-AI Learner's Journal Kit turns useful AI conversations, class notes, workshop exercises, and learning moments into a searchable Markdown journal.
+AI Learner's Journal Kit turns useful AI conversations, class notes, workshop exercises, and learning moments into a searchable journal that stays on your own computer.
 
-The current product is a local-first command-line tool with a beginner menu. It is suitable for training workshops, self-paced learners, and paid digital product distribution when packaged from a verified release artifact.
+## Start here — no coding required
 
-## Quick Start
+The friendly browser interface is the recommended way to use AI Journal.
 
 ### macOS
 
-1. Download the release ZIP or clone this repository.
-2. Right-click `installers/Installer.command`.
-3. Choose `Open`, then follow the prompts.
-4. Start the beginner menu:
+1. Download and unzip the customer release.
+2. Open the extracted folder.
+3. Double-click **START HERE - AI Journal.command**.
+4. Your browser opens automatically.
+5. Click **Ask the Guide**, **New entry**, or **Search my journal**.
 
-```bash
-ai-journal
-```
+Keep the small Terminal window open while the journal is running. To stop the journal, return to that window and press **Control + C**.
 
-You can also double-click `~/AI-Journal/Start AI Journal.command` after installation.
+If macOS blocks the launcher, right-click it, choose **Open**, and approve it. See `docs/Quick_Start_v3.md` for illustrated-style troubleshooting steps.
 
 ### Windows
 
-1. Download the release ZIP or clone this repository.
-2. Double-click `installers\Installer.bat`.
-3. Open a new Command Prompt and run:
+1. Download and unzip the customer release.
+2. Open the extracted folder.
+3. Double-click **START HERE - AI Journal.bat**.
+4. Your browser opens automatically.
+5. Click **Ask the Guide**, **New entry**, or **Search my journal**.
 
-```cmd
-ai-journal
-```
-
-If the new terminal does not recognize `ai-journal`, use:
-
-```cmd
-%USERPROFILE%\AI-Journal\ai-journal.bat
-```
-
-You can also double-click `%USERPROFILE%\AI-Journal\Start AI Journal.bat`.
+Keep the small command window open while the journal is running. Close it when finished.
 
 ### Linux
 
-```bash
-chmod +x installers/install_ai_journal_v3.sh
-./installers/install_ai_journal_v3.sh
-ai-journal
-```
-
-## Installation
-
-The installers copy the CLI wrapper and Python scripts into `~/AI-Journal` on macOS/Linux or `%USERPROFILE%\AI-Journal` on Windows. Existing journal entries are preserved.
-
-For paid distribution, use the versioned ZIP created by the release build script instead of asking customers to download a source snapshot.
-
-## Features
-
-- Beginner menu for non-coders: create, append, search, open, and check setup.
-- Direct CLI commands for workshop facilitators and power users.
-- Plain Markdown journal entries stored locally on the user's computer.
-- Search by topic or tag through a small JSON index.
-- Optional OpenAI workflow through `OPENAI_API_KEY`.
-- AI review score that estimates structure and completeness, not factual correctness.
-- Cross-platform installers for macOS, Windows, and Linux.
-- Release packaging script for customer-ready ZIP and tar.gz artifacts.
-
-## Beginner Menu
-
-Run `ai-journal` with no arguments:
-
-```text
-1. Create a new journal entry
-2. Add to latest entry
-3. Ask AI and save answer
-4. Search my journal
-5. Open latest entry
-6. Run setup check
-7. Quit
-```
-
-The menu asks for topics, notes, and search terms interactively, so users do not need to know terminal quoting rules.
-
-## Commands
+Linux users can run:
 
 ```bash
-ai-journal new "My First Learning Session" learning
-ai-journal append latest "A useful insight I want to remember"
-ai-journal search "docker"
-ai-journal list --limit 10
-ai-journal open latest
-ai-journal setup
+python3 scripts/web_server.py
 ```
 
-You can also run commands without text arguments and let the app prompt you:
+Then open the local address shown in the terminal.
+
+## First five minutes
+
+1. Click **New entry** and write one thing you learned.
+2. Click **Ask the Guide** and ask a complete question, such as “What does grep do?”
+3. Leave **Use my journal as context** checked when you want the Guide to build on your notes.
+4. Click **Search my journal** to find earlier learning.
+5. Use **Manage AI** to choose Groq, OpenAI, Claude, or Gemini when available.
+
+The core journal stores notes as plain Markdown files on your computer. Optional AI questions are sent only to the provider you configure.
+
+## AI setup for beginners
+
+The web interface is the primary setup path:
+
+1. Open AI Journal.
+2. Click **Ask the Guide**.
+3. Click **Manage AI**.
+4. Choose a provider.
+5. Paste that provider's API key.
+6. Click the connection test or save button.
+7. Ask a simple test question.
+
+Never share an API key in email, screenshots, support tickets, journal entries, or GitHub.
+
+## What is included
+
+- Friendly local browser interface
+- Plain-file journal stored on your computer
+- New entries, quick additions, search, progress, and badges
+- Ask the Guide with optional journal context
+- Optional multiple AI providers
+- Cross-platform launchers and installers
+- Advanced command-line interface for facilitators and power users
+
+## Advanced: Terminal users
+
+Terminal use is optional. See `OPTIONAL_READING_command-line.md`.
+
+Common commands:
 
 ```bash
-ai-journal new
-ai-journal append latest
-ai-journal search
+uv run ai-journal doctor
+uv run ai-journal find "grep"
+uv run ai-journal backup
 ```
 
-## If your computer blocks the app the first time
+## Paid downloads and storefronts
 
-Because this app is downloaded from the internet and is not yet signed by Apple
-or Microsoft, your computer may warn you the first time you open the launcher.
-Nothing is wrong with the file - this is the normal warning for new downloads.
+Customers should receive the versioned release ZIP produced by `scripts/build_release.py`, not GitHub's automatic “Source code” archive.
 
-**macOS** ("Apple could not verify..."): click **Done** (not "Move to Trash"),
-then open **System Settings -> Privacy & Security**, scroll to the Security
-section, and click **Open Anyway** next to "Start AI Journal.command". Enter your
-password if asked, then click **Open**. After this, double-clicking works.
+Before uploading to Gumroad, Payhip, Lemon Squeezy, or another platform, follow:
 
-**Windows** ("Windows protected your PC"): click **More info**, then **Run
-anyway**.
-
-### Still stuck on macOS? Run it from the Terminal
-
-This always works, even when the launcher is blocked:
-
-1. Open the **Terminal** app (press Cmd+Space, type `Terminal`, press Return).
-2. Type `cd ` (with a trailing space) but do **not** press Return yet.
-3. Drag the `ai-coding-journal-starter` folder onto the Terminal window - its
-   path is filled in for you - then press Return.
-4. Run:
-
-   ```bash
-   python3 scripts/journal_cli.py menu
-   ```
-
-Power-user shortcut to clear the quarantine flag once, then double-click as
-normal:
-
-```bash
-xattr -dr com.apple.quarantine ai-coding-journal-starter
-```
-
-## Turn on AI answers
-
-The journal works fully without AI, and beginner questions like "what is an
-API?" are answered offline by the built-in **Starter Guide** - no key needed.
-To get AI answers to *any* question, switch on full AI once by pasting a
-provider key. Recommended order for learners:
-
-- **Groq** - free, no card needed. The best option if you don't have a card.
-- **Claude** or **ChatGPT** - paid; need credits on your provider account.
-- **Gemini** - has a free tier, but Google now requires linking a billing card
-  to your Google account before it will work (otherwise you get a quota error).
-
-Then install the optional package and set your key:
-
-```bash
-python3 -m pip install -r requirements.txt
-export OPENAI_API_KEY="your-api-key-here"
-ai-journal ask "Explain photosynthesis for a beginner"
-```
-
-For Windows Command Prompt:
-
-```cmd
-set OPENAI_API_KEY=your-api-key-here
-ai-journal ask "Explain photosynthesis for a beginner"
-```
-
-AI Journal does not include an API key. Users are responsible for their own API
-usage and costs. The offline Starter Guide always works for free.
-
-## Workshop Use
-
-This repository includes a workshop guide for facilitators: `docs/Workshop_Facilitator_Guide.md`.
-
-Recommended workshop setup:
-
-- Distribute the release ZIP before the session.
-- Ask attendees to install Python 3.9 or newer before the workshop.
-- Start with the beginner menu, then show direct commands.
-- Use the optional AI workflow only after the core journal flow works.
-
-## Paid Product Use
-
-Use `docs/Paid_Product_Checklist.md` before publishing to Payhip, Gumroad, Lemon Squeezy, or another digital storefront.
-
-Minimum paid-product package:
-
-- Versioned release ZIP.
-- `README.md`
+- `docs/Storefront_Distribution_Checklist.md`
+- `docs/Paid_Product_Checklist.md`
 - `docs/Quick_Start_v3.md`
-- `SUPPORT.md`
-- `PRIVACY.md`
-- `REFUND_POLICY.md`
-- `SECURITY.md`
-- `CHANGELOG.md`
-- SHA256 checksums from the release build.
 
-## Journal Storage
+The release builder now requires the web-first launchers and onboarding documents, preventing a customer package from being built without them.
 
-Entries are stored as Markdown in `~/AI-Journal`:
+## Support, privacy, and safety
 
-```text
-~/AI-Journal/
-  entries/
-    2026/
-      05/
-        20260523-my-topic.md
-  media/
-  scripts/
-  index.json
-```
+See `SUPPORT.md`, `PRIVACY.md`, `SECURITY.md`, and `REFUND_POLICY.md`.
 
-Because entries are plain Markdown, users can read, edit, back up, or export them with ordinary tools.
-
-## Documentation
-
-- `docs/Quick_Start_v3.md` - step-by-step beginner guide.
-- `docs/Workshop_Facilitator_Guide.md` - training workshop runbook.
-- `docs/Paid_Product_Checklist.md` - storefront and release checklist.
-- `docs/Release_Checklist.md` - engineering release gate.
-- `docs/Release_Notes_v3.0.1.md` - corrected release note template.
-- `OPTIONAL_READING_command-line.md` - command-line background.
-- `demo/usage-examples.md` - copy-paste examples.
-
-## Support
-
-See `SUPPORT.md` for workshop and paid-customer support expectations.
-
-## Privacy
-
-See `PRIVACY.md`. The core journal stores data locally. Optional AI prompts are sent to OpenAI only when the user configures an API key and runs `ai-journal ask`.
-
-## License
-
-AI Learner's Journal Kit is licensed under the **PolyForm Noncommercial License 1.0.0**.
-It is free to use, modify, and share for **noncommercial** purposes, including
-personal study and use by educational institutions, nonprofits, public research
-organizations, and government bodies.
-
-**Commercial use** — including selling the software, charging for it, or charging
-for a product or service built substantially on it — **requires a separate
-commercial license.** For commercial licensing, contact Lawrence Agbemabiese
-<agbe@udel.edu>. See `LICENSE` for full terms.
+AI answers may be wrong. Verify medical, legal, financial, security, and other high-stakes information with a qualified source.

--- a/README.txt
+++ b/README.txt
@@ -1,54 +1,28 @@
-AI Learner's Journal Kit v3.0
+AI LEARNER'S JOURNAL KIT — START HERE
 
-QUICK START
+NO CODING REQUIRED
 
-macOS:
-1. Right-click installers/Installer.command
-2. Choose Open
-3. Double-click ~/AI-Journal/Start AI Journal.command
+MAC
+1. Unzip the download.
+2. Open the extracted folder.
+3. Double-click: START HERE - AI Journal.command
+4. Leave the Terminal window open while using the browser journal.
 
-Windows:
-1. Double-click installers\Installer.bat
-2. Open a new Command Prompt and run ai-journal
-3. Or double-click %USERPROFILE%\AI-Journal\Start AI Journal.bat
+WINDOWS
+1. Extract the download.
+2. Open the extracted folder.
+3. Double-click: START HERE - AI Journal.bat
+4. Leave the command window open while using the browser journal.
 
-Linux:
-1. Run: chmod +x installers/install_ai_journal_v3.sh
-2. Run: ./installers/install_ai_journal_v3.sh
-3. Run: ai-journal
+IN THE BROWSER
+- Ask the Guide: ask complete learning questions
+- New entry: save what you learned
+- Search my journal: find previous notes
+- Manage AI: choose Groq, OpenAI, Claude, or Gemini when available
 
-BEGINNER MENU
+Your notes stay as plain files on your own computer.
 
-Run ai-journal with no arguments to open a menu:
-1. Create a new journal entry
-2. Add to latest entry
-3. Ask AI and save answer
-4. Search my journal
-5. Open latest entry
-6. Run setup check
-7. Quit
+Never share an API key in screenshots, email, support requests, journal entries, or GitHub.
 
-WHAT IS INCLUDED
-
-- ai-journal CLI and beginner menu
-- Python scripts for saving, appending, listing, searching, and opening entries
-- Optional OpenAI integration using the user's own OPENAI_API_KEY
-- macOS, Linux, and Windows installers
-- Double-click launchers for macOS and Windows
-- Workshop and paid-product readiness documentation
-- Support, privacy, refund, and security policies
-
-NOTES
-
-The core journal works without an API key.
-
-The optional AI workflow requires the OpenAI package and OPENAI_API_KEY.
-
-AI review scores estimate structure and completeness, not factual correctness.
-Verify high-stakes topics with a trusted expert or source.
-
-Read SUPPORT.md, PRIVACY.md, REFUND_POLICY.md, and SECURITY.md before paid distribution.
-
-Version: 3.0
-License: PolyForm Noncommercial License 1.0.0 (commercial use requires a separate
-license; contact agbe@udel.edu). See LICENSE.
+For full instructions, open docs/Quick_Start_v3.md.
+Terminal commands are optional and documented separately.

--- a/START HERE - AI Journal.bat
+++ b/START HERE - AI Journal.bat
@@ -1,0 +1,19 @@
+@echo off
+REM Friendly top-level launcher for non-technical Windows users.
+cd /d "%~dp0"
+
+if exist "Start AI Journal (Web).bat" (
+  call "Start AI Journal (Web).bat"
+  exit /b
+)
+
+if exist "scripts\web_server.py" (
+  echo Starting AI Journal...
+  echo Your browser will open automatically.
+  echo Keep this window open while using the journal.
+  python "scripts\web_server.py"
+) else (
+  echo AI Journal files could not be found.
+  echo Please read START_HERE.md or contact support.
+  pause
+)

--- a/START HERE - AI Journal.command
+++ b/START HERE - AI Journal.command
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Friendly top-level launcher for non-technical macOS users.
+set -e
+cd "$(dirname "$0")"
+
+if [ -f "Start AI Journal (Web).command" ]; then
+  exec bash "Start AI Journal (Web).command"
+fi
+
+if [ -f "scripts/web_server.py" ]; then
+  echo "Starting AI Journal..."
+  echo "Your browser will open automatically."
+  echo "Keep this window open while using the journal."
+  python3 "scripts/web_server.py"
+else
+  echo "AI Journal files could not be found."
+  echo "Please read START_HERE.md or contact support."
+  read -r -p "Press Return to close."
+fi

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,0 +1,30 @@
+# START HERE
+
+Welcome to AI Learner's Journal Kit.
+
+## Mac
+
+Double-click:
+
+```text
+START HERE - AI Journal.command
+```
+
+## Windows
+
+Double-click:
+
+```text
+START HERE - AI Journal.bat
+```
+
+The journal opens in your browser. You do not need to learn Terminal commands.
+
+After it opens:
+
+1. Click **Ask the Guide** to ask a learning question.
+2. Click **New entry** to write a note.
+3. Click **Search my journal** to find previous learning.
+4. Click **Manage AI** inside Ask the Guide to choose an AI provider.
+
+Full instructions: `docs/Quick_Start_v3.md`

--- a/docs/Paid_Product_Checklist.md
+++ b/docs/Paid_Product_Checklist.md
@@ -2,53 +2,75 @@
 
 Use this checklist before publishing a paid digital product.
 
-## Product Truth
+## Novice-first onboarding
 
-- README describes only features that exist in the current release.
-- Release notes do not advertise unsupported multi-AI comparison.
-- Screenshots and sales copy match the current beginner menu and command set.
-- Product page explains that Python 3.9 or newer is required.
-- Product page explains that OpenAI usage is optional and requires the customer's own API key.
+- The product ZIP contains `START_HERE.md`.
+- The ZIP contains `START HERE - AI Journal.command`.
+- The ZIP contains `START HERE - AI Journal.bat`.
+- `README.md` leads with the browser interface, not Terminal.
+- `README.txt` gives the same browser-first instructions.
+- `docs/Quick_Start_v3.md` assumes no coding knowledge.
+- AI setup is explained through **Ask the Guide → Manage AI**.
+- Terminal commands are labeled advanced or optional.
+- A clean Mac user can reach the browser UI without reading command-line instructions.
+- A clean Windows user can reach the browser UI without opening Command Prompt manually.
+
+## Product truth
+
+- README describes only features in the current release.
+- Screenshots match the current browser UI.
+- Sales copy does not promise bundled API access.
+- Product page explains that AI providers may require the customer's own key and usage credits.
+- Product page explains that notes are stored locally.
+- Product page explains that the local launcher opens a browser interface.
 
 ## Package
 
-- Release ZIP was created from a clean working tree.
-- ZIP includes installers, scripts, launchers, docs, demo content, license, and policies.
-- ZIP excludes `.git`, virtual environments, caches, local journals, and test output.
+- Release archive was created with `scripts/build_release.py`.
+- Do not upload GitHub's automatic source archive to a storefront.
+- ZIP includes launchers, web UI, scripts, docs, support files, license, and policies.
+- ZIP excludes `.git`, virtual environments, caches, local journals, secrets, and test output.
 - SHA256 checksums are generated.
-- Package was installed on a clean macOS or Linux test account.
-- Package was smoke-tested on Windows before paid launch.
+- `python3 scripts/verify_customer_package.py <release.zip>` passes.
+- Package was tested after downloading the exact storefront file.
 
 ## Storefront
 
-- Product title and subtitle are specific and current.
-- Refund policy is visible.
-- Support channel and response expectation are visible.
-- Privacy summary is visible.
-- Download file is the release ZIP, not a GitHub auto-generated source archive.
-- Version number is shown on the storefront.
+- The uploaded file is the versioned customer release ZIP.
+- Product description begins with “No coding required” or equivalent.
+- The first instruction says to double-click the START HERE launcher.
+- At least one current browser-interface screenshot is shown.
+- Version number is visible.
+- Support, refund, privacy, and license information are visible.
+- Download instructions do not point customers to GitHub unless intended.
 
-## Support Readiness
+## Delivery test
 
-- `SUPPORT.md` is included in the package.
+For every platform—Gumroad or any future store:
+
+1. Upload the versioned release ZIP.
+2. Purchase or download it through a test customer account.
+3. Compare its SHA256 hash with `dist/SHA256SUMS.txt`.
+4. Extract it into a new folder.
+5. Confirm the START HERE files are visible at the top level.
+6. Launch the browser UI.
+7. Create a test entry.
+8. Ask an offline or configured AI question.
+9. Confirm no developer files or private journal data are included.
+
+## Support readiness
+
+- `SUPPORT.md` is included.
 - Known setup issues have short canned responses.
-- A non-sensitive sample journal entry is available for troubleshooting.
-- The support workflow tells users not to share API keys.
+- Support instructions tell users not to share API keys.
+- A current screenshot of the home screen is available for support.
 
-## Legal And Trust
+## Launch gate
 
-- `LICENSE` is included.
-- `PRIVACY.md` is included.
-- `REFUND_POLICY.md` is included.
-- `SECURITY.md` is included.
-- The product page avoids guarantees about AI factual accuracy.
-
-## Launch Gate
-
-Do not publish a paid release unless:
+Do not publish unless:
 
 - Local tests pass.
-- CI passes on the release commit.
-- The release artifact exists.
-- Release notes match the artifact.
-- A clean install smoke test passes from the artifact.
+- CI passes.
+- Customer ZIP passes `verify_customer_package.py`.
+- A clean install succeeds from the exact ZIP uploaded to the store.
+- Store listing and screenshots match the included version.

--- a/docs/Quick_Start_v3.md
+++ b/docs/Quick_Start_v3.md
@@ -57,9 +57,9 @@ If macOS still blocks it:
 What does grep do?
 ```
 
-3. Leave **Use my journal as context** checked when useful.
-4. Click **Ask**.
-5. Expand **Show steps** for more detail.
+1. Leave **Use my journal as context** checked when useful.
+2. Click **Ask**.
+3. Expand **Show steps** for more detail.
 
 The answer is saved to your journal automatically.
 

--- a/docs/Quick_Start_v3.md
+++ b/docs/Quick_Start_v3.md
@@ -1,189 +1,107 @@
-# AI Learner's Journal Kit v3.0 Quick Start
+# Quick Start — Friendly Browser Version
 
-This guide is for people who want the easiest path first. You can use AI Journal from a double-click menu and do not need to memorize terminal commands.
+This guide is written for people who do not code and do not want to use Terminal commands.
 
-## 1. Install
+## The one thing to remember
 
-### macOS
-
-1. Open the downloaded folder.
-2. Open the `installers` folder.
-3. Right-click `Installer.command`.
-4. Choose `Open`.
-5. Choose `Open` again if macOS shows a security warning.
-6. Follow the prompts.
-
-After installation, double-click:
+Open the downloaded folder and double-click the file whose name begins with:
 
 ```text
-~/AI-Journal/Start AI Journal.command
+START HERE - AI Journal
 ```
 
-### Windows
+That opens the friendly journal in your browser.
 
-1. Open the downloaded folder.
-2. Open the `installers` folder.
-3. Double-click `Installer.bat`.
-4. Follow the prompts.
+## macOS
 
-After installation, double-click:
+1. Download the product ZIP.
+2. Double-click the ZIP to extract it.
+3. Open the new folder.
+4. Find **START HERE - AI Journal.command**.
+5. Double-click it.
+6. Leave the small Terminal window open.
+7. Use the journal in the browser window that opens.
+
+### If macOS blocks it
+
+1. Right-click **START HERE - AI Journal.command**.
+2. Choose **Open**.
+3. Choose **Open** again.
+
+If macOS still blocks it:
+
+1. Open **System Settings**.
+2. Choose **Privacy & Security**.
+3. Scroll to **Security**.
+4. Click **Open Anyway** beside the AI Journal launcher.
+5. Return to the folder and double-click the launcher again.
+
+## Windows
+
+1. Download the product ZIP.
+2. Right-click the ZIP and choose **Extract All**.
+3. Open the extracted folder.
+4. Double-click **START HERE - AI Journal.bat**.
+5. If Windows shows “Windows protected your PC,” click **More info**, then **Run anyway**.
+6. Leave the small command window open.
+7. Use the journal in the browser window that opens.
+
+## Your first learning session
+
+### Ask a question
+
+1. Click **Ask the Guide**.
+2. Type a complete question, such as:
 
 ```text
-%USERPROFILE%\AI-Journal\Start AI Journal.bat
+What does grep do?
 ```
 
-### Linux
+3. Leave **Use my journal as context** checked when useful.
+4. Click **Ask**.
+5. Expand **Show steps** for more detail.
 
-Open a terminal in the downloaded folder and run:
+The answer is saved to your journal automatically.
 
-```bash
-chmod +x installers/install_ai_journal_v3.sh
-./installers/install_ai_journal_v3.sh
-ai-journal
-```
+### Create a note
 
-## 2. Use The Menu
+1. Click **New entry**.
+2. Add a topic.
+3. Write what you learned.
+4. Save.
 
-When AI Journal starts, choose a number:
+### Find an old note
+
+1. Click **Search my journal**.
+2. Search with a word or phrase.
+3. Open the matching entry.
+
+## Turn on full AI
+
+1. Click **Ask the Guide**.
+2. Click **Manage AI**.
+3. Select a provider.
+4. Paste your own provider API key.
+5. Save or test the connection.
+
+Groq may offer a free option. Other providers may require paid API credits. ChatGPT subscriptions and OpenAI API billing are separate.
+
+Never send an API key to support or include it in a screenshot.
+
+## Where are my notes?
+
+Your notes remain as plain files on your computer, normally inside:
 
 ```text
-1. Create a new journal entry
-2. Add to latest entry
-3. Ask AI and save answer
-4. Search my journal
-5. Open latest entry
-6. Run setup check
-7. Quit
+~/AI-Journal
 ```
 
-The menu asks for the topic, notes, and search words. This avoids common terminal problems with quotes, spaces, question marks, and dollar signs.
+You can back up that folder with ordinary backup software.
 
-## 3. Create Your First Entry
+## Advanced options
 
-Choose `1. Create a new journal entry`.
+Terminal commands are optional. Curious users can read `OPTIONAL_READING_command-line.md`.
 
-Example topic:
+## Need help?
 
-```text
-What I learned about responsible AI today
-```
-
-Example tags:
-
-```text
-ai learning ethics
-```
-
-The entry is saved as a Markdown file inside `~/AI-Journal/entries`.
-
-## 4. Add Notes Later
-
-Choose `2. Add to latest entry`.
-
-Paste or type your note. Finish with a blank line.
-
-## 5. Search Your Journal
-
-Choose `4. Search my journal`.
-
-Search by topic or tag, such as:
-
-```text
-ethics
-docker
-lesson plan
-```
-
-## Optional: Ask AI From The Journal
-
-The journal works without an API key. To use the `ask` option with OpenAI:
-
-1. Get an API key from `https://platform.openai.com/api-keys`.
-2. Install the optional package:
-
-```bash
-python3 -m pip install -r requirements.txt
-```
-
-1. Set the key for your terminal session:
-
-```bash
-export OPENAI_API_KEY="your-api-key-here"
-```
-
-Then choose `3. Ask AI and save answer` from the menu, or run:
-
-```bash
-ai-journal ask "What is a learning objective?"
-```
-
-AI Journal shows a review score for structure and completeness. It is not a factual accuracy score. For medical, legal, financial, security, or other high-stakes topics, verify with a trusted expert or source.
-
-## Optional: Direct Commands
-
-If you are comfortable in a terminal, these commands still work:
-
-```bash
-ai-journal new "My First Learning Session" learning
-ai-journal append latest "A useful insight"
-ai-journal search "learning"
-ai-journal list --limit 10
-ai-journal open latest
-ai-journal setup
-```
-
-You can also leave off the text and let AI Journal prompt you:
-
-```bash
-ai-journal new
-ai-journal append latest
-ai-journal search
-```
-
-## Troubleshooting
-
-### The command `ai-journal` is not found
-
-On macOS, double-click:
-
-```text
-~/AI-Journal/Start AI Journal.command
-```
-
-On Windows, double-click:
-
-```text
-%USERPROFILE%\AI-Journal\Start AI Journal.bat
-```
-
-You can also run the setup check from the installed menu.
-
-### AI does not answer
-
-Check that the optional package is installed and the API key is set:
-
-```bash
-python3 -m pip install -r requirements.txt
-echo $OPENAI_API_KEY
-```
-
-If no key is configured, AI Journal creates a manual entry instead of stopping.
-
-### I prefer plain terminal output
-
-Use:
-
-```bash
-ai-journal ask "What is Docker?" --plain
-```
-
-## Support And Privacy
-
-For workshop or paid-product distribution, include these files with the download:
-
-- `SUPPORT.md`
-- `PRIVACY.md`
-- `REFUND_POLICY.md`
-- `SECURITY.md`
-
-The core journal stores entries locally. The optional AI workflow sends prompts to OpenAI only when the user configures an API key and runs `ai-journal ask`.
+Read `SUPPORT.md`. When asking for help, share the error message but never share your API key.

--- a/docs/Storefront_Copy_Template.md
+++ b/docs/Storefront_Copy_Template.md
@@ -1,0 +1,43 @@
+# Storefront Copy Template
+
+## Headline
+
+AI Learner's Journal Kit — a private, browser-based learning journal with optional AI guidance
+
+## Opening
+
+**No coding required.** Download the ZIP, open the folder, and double-click the clearly labeled START HERE file. Your journal opens in your browser and stores your notes as plain files on your own computer.
+
+## What customers can do
+
+- Ask complete learning questions through Ask the Guide
+- Build answers on their own journal notes
+- Save new learning entries
+- Search previous notes
+- Track activity and learning streaks
+- Choose an optional AI provider
+- Keep journal files locally
+
+## Important AI note
+
+AI provider access is optional. Customers use their own API key and are responsible for provider charges. API access is not included in the product price. The product can still store and search journal notes without paid AI access.
+
+## System requirements
+
+- macOS or Windows
+- Python as specified in the included Quick Start
+- A modern web browser
+- Internet access only when using an external AI provider
+
+## First step after download
+
+Mac: double-click `START HERE - AI Journal.command`.
+
+Windows: double-click `START HERE - AI Journal.bat`.
+
+## Trust notes
+
+- Notes are stored locally as plain files.
+- The app opens on a local address in the customer's browser.
+- Customers should never share API keys.
+- AI answers should be checked for high-stakes decisions.

--- a/docs/Storefront_Distribution_Checklist.md
+++ b/docs/Storefront_Distribution_Checklist.md
@@ -1,0 +1,66 @@
+# Storefront Distribution Checklist
+
+This checklist ensures that Gumroad and future platforms deliver the novice-friendly browser version.
+
+## Canonical customer artifact
+
+The only customer download should be the versioned ZIP built by:
+
+```bash
+python3 scripts/build_release.py --version vX.Y.Z
+```
+
+Do not use GitHub's automatically generated “Source code (zip)” file. It is not the customer-tested artifact.
+
+## Files that must be visible after extraction
+
+- `START HERE - AI Journal.command`
+- `START HERE - AI Journal.bat`
+- `START_HERE.md`
+- `README.txt`
+- `docs/Quick_Start_v3.md`
+
+## Verify the archive
+
+```bash
+python3 scripts/verify_customer_package.py dist/ai-learners-journal-kit-vX.Y.Z.zip
+```
+
+The command must finish with:
+
+```text
+Customer package verification passed.
+```
+
+## Gumroad
+
+1. Open the product's Content or Files area.
+2. Remove obsolete ZIPs or label them clearly as old versions.
+3. Upload the new versioned release ZIP.
+4. Put the version number in the filename and product update note.
+5. Add the text from `docs/Storefront_Copy_Template.md`.
+6. Add current screenshots of:
+   - the browser home screen,
+   - Ask the Guide,
+   - Manage AI.
+7. Use a test purchase or complimentary download.
+8. Verify the downloaded file with the package checker.
+9. Confirm the customer sees START HERE immediately after extraction.
+
+## Future platforms
+
+Repeat the same procedure on Payhip, Lemon Squeezy, Shopify, Etsy digital delivery, or another platform. The platform may change, but the canonical ZIP and verification steps do not.
+
+## Release record
+
+For each upload, record:
+
+- platform,
+- product name,
+- version,
+- upload date,
+- exact ZIP filename,
+- SHA256,
+- test-download result,
+- tester name,
+- screenshots updated: yes/no.

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -38,6 +38,15 @@ EXCLUDED_FILES = {
 
 REQUIRED_FILES = [
     "README.md",
+    "README.txt",
+    "START_HERE.md",
+    "START HERE - AI Journal.command",
+    "START HERE - AI Journal.bat",
+    "Start AI Journal (Web).command",
+    "Start AI Journal (Web).bat",
+    "docs/Storefront_Distribution_Checklist.md",
+    "docs/Storefront_Copy_Template.md",
+    "scripts/verify_customer_package.py",
     "LICENSE",
     "CHANGELOG.md",
     "SUPPORT.md",

--- a/scripts/verify_customer_package.py
+++ b/scripts/verify_customer_package.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Verify that a customer release archive contains novice-first onboarding."""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+REQUIRED_SUFFIXES = (
+    "START HERE - AI Journal.command",
+    "START HERE - AI Journal.bat",
+    "START_HERE.md",
+    "README.md",
+    "README.txt",
+    "docs/Quick_Start_v3.md",
+    "docs/Storefront_Distribution_Checklist.md",
+    "SUPPORT.md",
+    "PRIVACY.md",
+    "SECURITY.md",
+    "REFUND_POLICY.md",
+    "Start AI Journal (Web).command",
+    "Start AI Journal (Web).bat",
+    "scripts/web_server.py",
+    "web/index.html",
+)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python3 scripts/verify_customer_package.py <release.zip>")
+        return 2
+
+    archive_path = Path(sys.argv[1])
+    if not archive_path.is_file():
+        print(f"Archive not found: {archive_path}")
+        return 2
+
+    with zipfile.ZipFile(archive_path) as archive:
+        names = archive.namelist()
+
+    missing = [
+        required
+        for required in REQUIRED_SUFFIXES
+        if not any(name.endswith(required) for name in names)
+    ]
+
+    if missing:
+        print("Customer package verification FAILED.")
+        print("Missing required files:")
+        for item in missing:
+            print(f"  - {item}")
+        return 1
+
+    print("Customer package verification passed.")
+    print(f"Checked {len(REQUIRED_SUFFIXES)} novice-first requirements.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This pull request makes the browser interface the primary onboarding path for non-technical users.

## Changes

- Rewrites README.md around “Start here — no coding required”
- Adds prominent Mac and Windows START HERE launchers
- Adds START_HERE.md
- Rewrites the Quick Start for browser-first use
- Moves Terminal instructions into an advanced section
- Directs AI configuration through Ask the Guide → Manage AI
- Adds storefront copy and distribution checklists
- Strengthens the paid-product checklist
- Updates the release builder to require novice onboarding files
- Adds a customer-package verification script

## Customer package verification

Built:

`dist/ai-learners-journal-kit-v3.2.0.zip`

Verification result:

- Customer package verification passed
- 15 novice-first requirements checked

## Local checks

- git diff --check: passed
- Python compilation for release and verification scripts: passed
- Customer release build: passed
- Customer package verification: passed
- Full test suite: 40 passed, 2 pre-existing AI fallback tests failed

## Safety

- Work was completed on a separate feature branch
- main was not modified directly
- The generated customer ZIP was not committed